### PR TITLE
Mono fix. Compiler warnings gives Error.Count>0. Use HasErrors instead

### DIFF
--- a/src/RazorTemplates.Core/TemplateCompiler.cs
+++ b/src/RazorTemplates.Core/TemplateCompiler.cs
@@ -67,7 +67,10 @@ namespace RazorTemplates.Core
 
             var parameters = CreateCompilerParameters(tempDirectory, assemblyFileNames);
             var compileResult = codeProvider.CompileAssemblyFromDom(parameters, compileUnit);
-            if (compileResult.Errors != null && compileResult.Errors.Count > 0)
+
+            // if (compileResult.Errors != null && compileResult.Errors.Count > 0)
+            // fix for mono: with compiler warnings then compileResult.Errors.Count > 0. Better to check HasErrors property
+            if (compileResult.Errors != null && compileResult.Errors.HasErrors)
                 throw new TemplateCompilationException(compileResult.Errors, sourceCode, templateBody);
 
             var fullClassName = TEMPLATES_NAMESPACE + "." + className;


### PR DESCRIPTION
This fork seems more active than the original and has an updated Nuget build. Also this PR is the same as one from darklx into original branch but was never approved. 